### PR TITLE
Update cobweb.py

### DIFF
--- a/httpreplay/cobweb.py
+++ b/httpreplay/cobweb.py
@@ -229,7 +229,7 @@ class HttpProtocol(Protocol):
             res = self.parse_response(ts, recv)
 
             # Report this stream as being a valid HTTP stream.
-            self.parent.handle(s, ts, protocols[protocol], req, res, tlsinfo)
+            self.parent.handle(s, ts, protocols[protocol], req, res)
         else:
 
             # This wasn't a valid HTTP stream so we forward the original TCP


### PR DESCRIPTION
To many arguments in call to self.parent.process() call on line 232 causing failure to decrypt TLS traffic.